### PR TITLE
Fix issue preventing files being selected twice

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="container py-10">
-    <form enctype="multipart/form-data" @submit.prevent="downloadAll">
+    <form
+      ref="form"
+      enctype="multipart/form-data"
+      @submit.prevent="downloadAll"
+    >
       <div class="bg-white rounded shadow-md">
         <div class="p-4 border-b">
           <div class="flex items-center justify-between">
@@ -131,6 +135,7 @@ export default {
   methods: {
     onChange(e) {
       this.$store.commit('uploads/addFiles', e.target.files)
+      this.$refs.form.reset()
     },
 
     async download(file) {


### PR DESCRIPTION
Fixes an issue where selecting an image from the file system, removing it from the list of emotes, and then selecting it again would fail to add the image to the list.